### PR TITLE
Force CPU if CUDA is not available

### DIFF
--- a/basicsr/models/base_model.py
+++ b/basicsr/models/base_model.py
@@ -16,7 +16,9 @@ class BaseModel():
 
     def __init__(self, opt):
         self.opt = opt
-        self.device = torch.device('cuda' if opt['num_gpu'] != 0 else 'cpu')
+        # Force CPU if CUDA is not available
+        use_cuda = opt['num_gpu'] != 0 and torch.cuda.is_available()
+        self.device = torch.device('cuda' if use_cuda else 'cpu')
         self.is_train = opt['is_train']
         self.schedulers = []
         self.optimizers = []


### PR DESCRIPTION
Updated device assignment logic to check for CUDA availability.
Even if the user wants GPUs, the system needs to have CUDA support

`opt['num_gpu'] != 0 and torch.cuda.is_available()`
Both conditions must be True to use CUDA. If either is False, the code falls back to CPU